### PR TITLE
Sword and Kettle Update 2.0

### DIFF
--- a/Assets/Kettle_WaterParticle_0.prefab
+++ b/Assets/Kettle_WaterParticle_0.prefab
@@ -12,6 +12,7 @@ GameObject:
   - component: {fileID: 8067218652021030369}
   - component: {fileID: 8067218652021030371}
   - component: {fileID: 521546447354334080}
+  - component: {fileID: 448583498206060943}
   m_Layer: 0
   m_Name: Kettle_WaterParticle_0
   m_TagString: WaterParticle
@@ -119,3 +120,19 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 12293495583b8124da4dc9c512db4808, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!58 &448583498206060943
+CircleCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8067218652021030374}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IsTrigger: 1
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0, y: 0}
+  serializedVersion: 2
+  m_Radius: 0.25

--- a/Assets/Kettle_WaterParticle_SP Variant.prefab
+++ b/Assets/Kettle_WaterParticle_SP Variant.prefab
@@ -1,0 +1,89 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &1956532124260809993
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 8067218652021030368, guid: 828921abc8a3203459b63494fd2627ab, type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8067218652021030368, guid: 828921abc8a3203459b63494fd2627ab, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -0.071
+      objectReference: {fileID: 0}
+    - target: {fileID: 8067218652021030368, guid: 828921abc8a3203459b63494fd2627ab, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.005
+      objectReference: {fileID: 0}
+    - target: {fileID: 8067218652021030368, guid: 828921abc8a3203459b63494fd2627ab, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8067218652021030368, guid: 828921abc8a3203459b63494fd2627ab, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8067218652021030368, guid: 828921abc8a3203459b63494fd2627ab, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8067218652021030368, guid: 828921abc8a3203459b63494fd2627ab, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8067218652021030368, guid: 828921abc8a3203459b63494fd2627ab, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8067218652021030368, guid: 828921abc8a3203459b63494fd2627ab, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8067218652021030368, guid: 828921abc8a3203459b63494fd2627ab, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8067218652021030368, guid: 828921abc8a3203459b63494fd2627ab, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8067218652021030369, guid: 828921abc8a3203459b63494fd2627ab, type: 3}
+      propertyPath: m_Color.b
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8067218652021030369, guid: 828921abc8a3203459b63494fd2627ab, type: 3}
+      propertyPath: m_Color.g
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8067218652021030369, guid: 828921abc8a3203459b63494fd2627ab, type: 3}
+      propertyPath: m_Color.r
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8067218652021030374, guid: 828921abc8a3203459b63494fd2627ab, type: 3}
+      propertyPath: m_Name
+      value: Kettle_WaterParticle_SP
+      objectReference: {fileID: 0}
+    m_RemovedComponents:
+    - {fileID: 521546447354334080, guid: 828921abc8a3203459b63494fd2627ab, type: 3}
+  m_SourcePrefab: {fileID: 100100000, guid: 828921abc8a3203459b63494fd2627ab, type: 3}
+--- !u!1 &8417925923187900655 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 8067218652021030374, guid: 828921abc8a3203459b63494fd2627ab, type: 3}
+  m_PrefabInstance: {fileID: 1956532124260809993}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &6493175039968178850
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8417925923187900655}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 91aa3247130664342b09071b348ab3a7, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 

--- a/Assets/Kettle_WaterParticle_SP Variant.prefab.meta
+++ b/Assets/Kettle_WaterParticle_SP Variant.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: be0fd6ba96a77f948a1b0d9544846c32
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scenes/ShenScene.unity
+++ b/Assets/Scenes/ShenScene.unity
@@ -517,6 +517,139 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 197927164}
   m_CullTransparentMesh: 1
+--- !u!1 &274693423
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 274693427}
+  - component: {fileID: 274693426}
+  - component: {fileID: 274693425}
+  - component: {fileID: 274693424}
+  m_Layer: 0
+  m_Name: Wall
+  m_TagString: Wall
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!50 &274693424
+Rigidbody2D:
+  serializedVersion: 4
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 274693423}
+  m_BodyType: 1
+  m_Simulated: 1
+  m_UseFullKinematicContacts: 0
+  m_UseAutoMass: 0
+  m_Mass: 1
+  m_LinearDrag: 0
+  m_AngularDrag: 0.05
+  m_GravityScale: 1
+  m_Material: {fileID: 0}
+  m_Interpolate: 0
+  m_SleepingMode: 1
+  m_CollisionDetection: 0
+  m_Constraints: 0
+--- !u!61 &274693425
+BoxCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 274693423}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0, y: 0}
+  m_SpriteTilingProperty:
+    border: {x: 0, y: 0, z: 0, w: 0}
+    pivot: {x: 0.5, y: 0.5}
+    oldSize: {x: 1, y: 0.9375}
+    newSize: {x: 0.16, y: 0.15}
+    adaptiveTilingThreshold: 0.5
+    drawMode: 0
+    adaptiveTiling: 0
+  m_AutoTiling: 0
+  serializedVersion: 2
+  m_Size: {x: 0.16, y: 0.15}
+  m_EdgeRadius: 0
+--- !u!212 &274693426
+SpriteRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 274693423}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_Sprite: {fileID: 1415385719, guid: d118b138042747b43a055a5aee404e40, type: 3}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 0.16, y: 0.15}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_MaskInteraction: 0
+  m_SpriteSortPoint: 0
+--- !u!4 &274693427
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 274693423}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 1.26, y: 0.588, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 5
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &494212401
 GameObject:
   m_ObjectHideFlags: 0
@@ -708,7 +841,7 @@ BoxCollider2D:
   m_SpriteTilingProperty:
     border: {x: 0, y: 0, z: 0, w: 0}
     pivot: {x: 0.5, y: 0.5}
-    oldSize: {x: 0.1625, y: 0.1625}
+    oldSize: {x: 1, y: 1}
     newSize: {x: 0.13, y: 0.13}
     adaptiveTilingThreshold: 0.5
     drawMode: 0
@@ -863,11 +996,12 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   player: {fileID: 0}
-  hold: 0
+  hold: 2
   sword: {fileID: 1993685403}
   holdSword: {fileID: 1460415029}
   kettle: {fileID: 1580569860}
   waterParticle: {fileID: 8067218652021030374, guid: 828921abc8a3203459b63494fd2627ab, type: 3}
+  specialParticle: {fileID: 8417925923187900655, guid: be0fd6ba96a77f948a1b0d9544846c32, type: 3}
 --- !u!1 &742335516
 GameObject:
   m_ObjectHideFlags: 0
@@ -1077,7 +1211,7 @@ BoxCollider2D:
   m_SpriteTilingProperty:
     border: {x: 0, y: 0, z: 0, w: 0}
     pivot: {x: 0.5, y: 0.5}
-    oldSize: {x: 0.16, y: 0.15}
+    oldSize: {x: 1, y: 0.9375}
     newSize: {x: 0.16, y: 0.15}
     adaptiveTilingThreshold: 0.5
     drawMode: 0
@@ -1146,7 +1280,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 798420707}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0.44237626, y: -0.3524188, z: 0}
+  m_LocalPosition: {x: 1.26, y: -0.3524188, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -1909,7 +2043,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1460415029}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: -0.0569, y: 0.06889676, z: 0}
+  m_LocalPosition: {x: -0.312, y: 0.262, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -1980,7 +2114,7 @@ GameObject:
   - component: {fileID: 1580569865}
   - component: {fileID: 1580569862}
   - component: {fileID: 1580569863}
-  - component: {fileID: 1580569864}
+  - component: {fileID: 1580569866}
   m_Layer: 0
   m_Name: Kettle
   m_TagString: Holding
@@ -1996,7 +2130,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1580569860}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0.08, y: 0.02, z: 0}
+  m_LocalPosition: {x: 0.38, y: 0.07, z: 0}
   m_LocalScale: {x: -1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -2075,32 +2209,6 @@ Animator:
   m_HasTransformHierarchy: 1
   m_AllowConstantClipSamplingOptimization: 1
   m_KeepAnimatorControllerStateOnDisable: 0
---- !u!61 &1580569864
-BoxCollider2D:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1580569860}
-  m_Enabled: 1
-  m_Density: 1
-  m_Material: {fileID: 0}
-  m_IsTrigger: 1
-  m_UsedByEffector: 0
-  m_UsedByComposite: 0
-  m_Offset: {x: -0.16, y: 0}
-  m_SpriteTilingProperty:
-    border: {x: 0, y: 0, z: 0, w: 0}
-    pivot: {x: 0.5, y: 0.5}
-    oldSize: {x: 0.2, y: 0.2}
-    newSize: {x: 1, y: 1}
-    adaptiveTilingThreshold: 0.5
-    drawMode: 0
-    adaptiveTiling: 0
-  m_AutoTiling: 0
-  serializedVersion: 2
-  m_Size: {x: 0.48, y: 0.16}
-  m_EdgeRadius: 0
 --- !u!114 &1580569865
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -2115,6 +2223,32 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   tar: {fileID: 0}
   tar_1: {fileID: 0}
+--- !u!61 &1580569866
+BoxCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1580569860}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IsTrigger: 1
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: -1, y: 0}
+  m_SpriteTilingProperty:
+    border: {x: 0, y: 0, z: 0, w: 0}
+    pivot: {x: 0.5, y: 0.5}
+    oldSize: {x: 1, y: 1}
+    newSize: {x: 1, y: 1}
+    adaptiveTilingThreshold: 0.5
+    drawMode: 0
+    adaptiveTiling: 0
+  m_AutoTiling: 0
+  serializedVersion: 2
+  m_Size: {x: 3, y: 1}
+  m_EdgeRadius: 0
 --- !u!1 &1744881004
 GameObject:
   m_ObjectHideFlags: 0
@@ -2231,8 +2365,8 @@ MonoBehaviour:
       m_Calls: []
   m_text: 60
   m_isRightToLeft: 0
-  m_fontAsset: {fileID: 11400000, guid: 9bd371d318587b3489d737de409b40c7, type: 2}
-  m_sharedMaterial: {fileID: -3374399367440170044, guid: 9bd371d318587b3489d737de409b40c7, type: 2}
+  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
   m_fontSharedMaterials: []
   m_fontMaterial: {fileID: 0}
   m_fontMaterials: []
@@ -2336,9 +2470,9 @@ GameObject:
   m_Component:
   - component: {fileID: 1993685404}
   - component: {fileID: 1993685405}
-  - component: {fileID: 1993685406}
   - component: {fileID: 1993685407}
   - component: {fileID: 1993685408}
+  - component: {fileID: 1993685409}
   m_Layer: 0
   m_Name: Sword
   m_TagString: Holding
@@ -2354,7 +2488,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1993685403}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0.175, z: 0}
+  m_LocalPosition: {x: 0, y: 1.35, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -2413,32 +2547,6 @@ SpriteRenderer:
   m_WasSpriteAssigned: 1
   m_MaskInteraction: 0
   m_SpriteSortPoint: 0
---- !u!61 &1993685406
-BoxCollider2D:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1993685403}
-  m_Enabled: 1
-  m_Density: 1
-  m_Material: {fileID: 0}
-  m_IsTrigger: 1
-  m_UsedByEffector: 0
-  m_UsedByComposite: 0
-  m_Offset: {x: 0, y: 0}
-  m_SpriteTilingProperty:
-    border: {x: 0, y: 0, z: 0, w: 0}
-    pivot: {x: 0.5, y: 0.5}
-    oldSize: {x: 0.3, y: 0.3}
-    newSize: {x: 0.3, y: 0.3}
-    adaptiveTilingThreshold: 0.5
-    drawMode: 0
-    adaptiveTiling: 0
-  m_AutoTiling: 0
-  serializedVersion: 2
-  m_Size: {x: 0.12, y: 0.17}
-  m_EdgeRadius: 0
 --- !u!114 &1993685407
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -2473,6 +2581,32 @@ Animator:
   m_HasTransformHierarchy: 1
   m_AllowConstantClipSamplingOptimization: 1
   m_KeepAnimatorControllerStateOnDisable: 0
+--- !u!61 &1993685409
+BoxCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1993685403}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IsTrigger: 1
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0, y: 0}
+  m_SpriteTilingProperty:
+    border: {x: 0, y: 0, z: 0, w: 0}
+    pivot: {x: 0.5, y: 0.5}
+    oldSize: {x: 1.5, y: 1.5}
+    newSize: {x: 0.3, y: 0.3}
+    adaptiveTilingThreshold: 0.5
+    drawMode: 0
+    adaptiveTiling: 0
+  m_AutoTiling: 0
+  serializedVersion: 2
+  m_Size: {x: 1, y: 1.5}
+  m_EdgeRadius: 0
 --- !u!1 &2013173742
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/Player_UsingHoldItem.cs
+++ b/Assets/Scripts/Player_UsingHoldItem.cs
@@ -22,13 +22,19 @@ public class Player_UsingHoldItem : MonoBehaviour
     public GameObject sword;
     public GameObject holdSword;
     Animator sword_anim;
+    float stab_range;
+    int sp_counter;
 
     //Kettle
     public GameObject kettle;
     public GameObject waterParticle;
+    public GameObject specialParticle;
     Animator kettle_anim;
+
     void Start()
     {
+        sp_counter = 1;
+        stab_range = 1.2f;
         player = GameObject.Find("Player");
         sword_anim = sword.GetComponent<Animator>();
         kettle_anim=kettle.GetComponent<Animator>();
@@ -48,11 +54,12 @@ public class Player_UsingHoldItem : MonoBehaviour
 
             case Holdable.Kettle:
                 kettle.GetComponent<SpriteRenderer>().enabled = true;
+                holdSword.GetComponent<SpriteRenderer>().enabled = false;
                 watering();
                 break;
             default:
                 kettle.GetComponent<SpriteRenderer>().enabled = false;
-               holdSword.GetComponent<SpriteRenderer>().enabled = false;
+                holdSword.GetComponent<SpriteRenderer>().enabled = false;
                 break;
         }
     }
@@ -61,12 +68,12 @@ public class Player_UsingHoldItem : MonoBehaviour
         switch (face)
         {
             case 1:
-                kettle.transform.position = new Vector3(player.transform.position.x - 0.08f, player.transform.position.y + 0.02f, 0);
+                kettle.transform.position = new Vector3(player.transform.position.x - 0.38f, player.transform.position.y + 0.007f, 0);
                 kettle.transform.localScale = new Vector3(1f, 1f, 1f);
                 break;
 
             case 2:
-                kettle.transform.position = new Vector3(player.transform.position.x+0.08f, player.transform.position.y +0.02f, 0);
+                kettle.transform.position = new Vector3(player.transform.position.x+0.38f, player.transform.position.y +0.007f, 0);
                 kettle.transform.localScale = new Vector3(-1f,1f,1f);
                 break;
         }
@@ -74,11 +81,21 @@ public class Player_UsingHoldItem : MonoBehaviour
         {
             player.GetComponent<Player>().canMove = false;
             kettle_anim.SetBool("IsWatering",true);
-            GameObject tar = kettle.GetComponent<TriggerCheck>().tar_1;
+
             //Generate Water Particle
-            float particleSpeedUp = 20f;
-            float particleSpeed = 30f;
-            GameObject particle = Instantiate(waterParticle, new Vector3(kettle.transform.position.x, kettle.transform.position.y-0.01f, transform.position.z), transform.rotation);
+            float particleSpeedUp = 50f;
+            float particleSpeed = 100f;
+            GameObject particle;
+            if (sp_counter>0)
+            {
+                //Modifu "WaterParticle_SP" to make watering effect
+                sp_counter--;
+                particle = Instantiate(specialParticle, new Vector3(kettle.transform.position.x, kettle.transform.position.y - 0.01f, transform.position.z), transform.rotation);
+            }
+            else
+            {
+                particle = Instantiate(waterParticle, new Vector3(kettle.transform.position.x, kettle.transform.position.y - 0.01f, transform.position.z), transform.rotation);
+            }
             if (face==1)
             {
                 particleSpeed = -particleSpeed;
@@ -86,22 +103,46 @@ public class Player_UsingHoldItem : MonoBehaviour
 
             particle.GetComponent<Rigidbody2D>().AddForce(transform.right * particleSpeed*Random.Range(0.8f,1.2f));
             particle.GetComponent<Rigidbody2D>().AddForce(transform.up * particleSpeedUp * Random.Range(0.8f, 1.2f));
-            if (tar != null)
+            //GameObject tar = kettle.GetComponent<TriggerCheck>().tar_1; not use this, use special particle
+            /*if (tar != null)
             {
                 Debug.Log(tar.name);
                 kettle.GetComponent<TriggerCheck>().tar_1 = null;
-            }
+            }*/
         }
         else
         {
             player.GetComponent<Player>().canMove = true;
             kettle.GetComponent<TriggerCheck>().tar_1 = kettle.GetComponent<TriggerCheck>().tar;
             kettle_anim.SetBool("IsWatering", false);
+            sp_counter = 1;
         }
     }
 
     void swordAttack()
     {
+        if (Input.GetKeyDown(KeyCode.X))
+        {
+            stab_range = 1.2f;
+            sword_anim.SetTrigger("Stab");
+            player.GetComponent<Player>().canMove = false;
+            GameObject tar = sword.GetComponent<TriggerCheck>().tar_1;
+            if (tar != null)
+            {
+                Debug.Log(tar.name);
+                if (tar.CompareTag("Wall"))
+                {
+                    stab_range = 1.035f;
+                }
+                //Do something with tar
+                sword.GetComponent<TriggerCheck>().tar_1 = null;
+            }
+        }
+        else
+        {
+            sword.GetComponent<TriggerCheck>().tar_1 = sword.GetComponent<TriggerCheck>().tar;
+
+        }
         if (sword_anim.GetCurrentAnimatorStateInfo(0).IsName("Sword_Attack"))
         {
             holdSword.GetComponent<SpriteRenderer>().enabled = false;
@@ -115,54 +156,39 @@ public class Player_UsingHoldItem : MonoBehaviour
         switch (face)
         {
             case 1:
-                holdSword.transform.position = new Vector3(player.transform.position.x + 0.056f, player.transform.position.y + 0.0688f, 0);
+                holdSword.transform.position = new Vector3(player.transform.position.x + 0.312f, player.transform.position.y + 0.262f, 0);
                 holdSword.transform.localScale = new Vector3(-1f, 1f, 1f);
                 break;
 
             case 2:
-                holdSword.transform.position = new Vector3(player.transform.position.x -0.056f, player.transform.position.y + 0.0688f, 0);
+                holdSword.transform.position = new Vector3(player.transform.position.x -0.312f, player.transform.position.y + 0.263f, 0);
                 holdSword.transform.localScale = new Vector3(1f, 1f, 1f);
                 break;
         }
         switch (dir)
         {
             case 2:
-                sword.transform.position = new Vector3(player.transform.position.x, player.transform.position.y - 0.2f, 0);
+                sword.transform.position = new Vector3(player.transform.position.x, player.transform.position.y - stab_range, 0);
                 sword.transform.eulerAngles = new Vector3(0, 0, 180f);
                 //castDir = Vector2.down;
                 break;
             case 4:
-                sword.transform.position = new Vector3(player.transform.position.x - 0.2f, player.transform.position.y, 0);
+                sword.transform.position = new Vector3(player.transform.position.x - stab_range, player.transform.position.y, 0);
                 sword.transform.eulerAngles = new Vector3(0, 0, 90f);
                 //castDir = Vector2.left;
                 break;
             case 6:
-                sword.transform.position = new Vector3(player.transform.position.x + 0.2f, player.transform.position.y, 0);
+                sword.transform.position = new Vector3(player.transform.position.x + stab_range, player.transform.position.y, 0);
                 sword.transform.eulerAngles = new Vector3(0, 0, -90f);
                 //castDir = Vector2.right;
                 break;
             case 8:
-                sword.transform.position = new Vector3(player.transform.position.x, player.transform.position.y + 0.2f, 0);
+                sword.transform.position = new Vector3(player.transform.position.x, player.transform.position.y + stab_range, 0);
                 sword.transform.eulerAngles = new Vector3(0, 0, 0f);
                 //castDir = Vector2.up;
                 break;
         }
-        if (Input.GetKeyDown(KeyCode.X))
-        {
-            sword_anim.SetTrigger("Stab");
-            player.GetComponent<Player>().canMove = false;
-            GameObject tar = sword.GetComponent<TriggerCheck>().tar_1;
-            if (tar != null)
-            {
-                Debug.Log(tar.name);
-                //Do something with tar
-                sword.GetComponent<TriggerCheck>().tar_1 = null;
-            }
-        }
-        else
-        {
-            sword.GetComponent<TriggerCheck>().tar_1 = sword.GetComponent<TriggerCheck>().tar;
-        }
+       
     }
 }
 

--- a/Assets/Scripts/WaterParticle_SP.cs
+++ b/Assets/Scripts/WaterParticle_SP.cs
@@ -2,7 +2,7 @@ using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 
-public class WaterParticle : MonoBehaviour
+public class WaterParticle_SP : MonoBehaviour
 {
     GameObject player;
     float playerY;
@@ -28,7 +28,14 @@ public class WaterParticle : MonoBehaviour
     {
         if (collision && !collision.CompareTag("Holding") && !collision.CompareTag("WaterParticle"))
         {
+            Debug.Log("Sp Particle Hit!");
             Destroy(this.gameObject);
+            //Do something with watering
+            /*if (collision.GetComponent<>())
+            {
+                Waterable
+            }*/
         }
+        
     }
 }

--- a/Assets/Scripts/WaterParticle_SP.cs.meta
+++ b/Assets/Scripts/WaterParticle_SP.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 91aa3247130664342b09071b348ab3a7
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Sprites/133675.png.meta
+++ b/Assets/Sprites/133675.png.meta
@@ -47,7 +47,7 @@ TextureImporter:
   spriteMeshType: 1
   alignment: 0
   spritePivot: {x: 0.5, y: 0.5}
-  spritePixelsToUnits: 100
+  spritePixelsToUnits: 16
   spriteBorder: {x: 0, y: 0, z: 0, w: 0}
   spriteGenerateFallbackPhysicsShape: 1
   alphaUsage: 1
@@ -91,6 +91,18 @@ TextureImporter:
     forceMaximumCompressionQuality_BC6H_BC7: 0
   - serializedVersion: 3
     buildTarget: Server
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: WebGL
     maxTextureSize: 2048
     resizeAlgorithm: 0
     textureFormat: -1

--- a/Assets/Sprites/Player/HoldableItem/HoldSword.png.meta
+++ b/Assets/Sprites/Player/HoldableItem/HoldSword.png.meta
@@ -47,7 +47,7 @@ TextureImporter:
   spriteMeshType: 1
   alignment: 0
   spritePivot: {x: 0.5, y: 0.5}
-  spritePixelsToUnits: 80
+  spritePixelsToUnits: 16
   spriteBorder: {x: 0, y: 0, z: 0, w: 0}
   spriteGenerateFallbackPhysicsShape: 1
   alphaUsage: 1
@@ -70,7 +70,7 @@ TextureImporter:
     maxTextureSize: 2048
     resizeAlgorithm: 0
     textureFormat: -1
-    textureCompression: 1
+    textureCompression: 0
     compressionQuality: 50
     crunchedCompression: 0
     allowsAlphaSplitting: 0

--- a/Assets/Sprites/Player/HoldableItem/Kettle_WaterParticle.png.meta
+++ b/Assets/Sprites/Player/HoldableItem/Kettle_WaterParticle.png.meta
@@ -47,7 +47,7 @@ TextureImporter:
   spriteMeshType: 1
   alignment: 0
   spritePivot: {x: 0.5, y: 0.5}
-  spritePixelsToUnits: 80
+  spritePixelsToUnits: 16
   spriteBorder: {x: 0, y: 0, z: 0, w: 0}
   spriteGenerateFallbackPhysicsShape: 1
   alphaUsage: 1
@@ -70,7 +70,7 @@ TextureImporter:
     maxTextureSize: 2048
     resizeAlgorithm: 0
     textureFormat: -1
-    textureCompression: 1
+    textureCompression: 0
     compressionQuality: 50
     crunchedCompression: 0
     allowsAlphaSplitting: 0

--- a/Assets/Sprites/Player/HoldableItem/Kettle_Watering.png.meta
+++ b/Assets/Sprites/Player/HoldableItem/Kettle_Watering.png.meta
@@ -47,7 +47,7 @@ TextureImporter:
   spriteMeshType: 1
   alignment: 0
   spritePivot: {x: 0.5, y: 0.5}
-  spritePixelsToUnits: 80
+  spritePixelsToUnits: 16
   spriteBorder: {x: 0, y: 0, z: 0, w: 0}
   spriteGenerateFallbackPhysicsShape: 1
   alphaUsage: 1
@@ -70,7 +70,7 @@ TextureImporter:
     maxTextureSize: 2048
     resizeAlgorithm: 0
     textureFormat: -1
-    textureCompression: 1
+    textureCompression: 0
     compressionQuality: 50
     crunchedCompression: 0
     allowsAlphaSplitting: 0

--- a/Assets/Sprites/Player/HoldableItem/Spr_Sword_Stab.png.meta
+++ b/Assets/Sprites/Player/HoldableItem/Spr_Sword_Stab.png.meta
@@ -47,7 +47,7 @@ TextureImporter:
   spriteMeshType: 1
   alignment: 0
   spritePivot: {x: 0.5, y: 0.5}
-  spritePixelsToUnits: 80
+  spritePixelsToUnits: 16
   spriteBorder: {x: 0, y: 0, z: 0, w: 0}
   spriteGenerateFallbackPhysicsShape: 1
   alphaUsage: 1
@@ -70,7 +70,7 @@ TextureImporter:
     maxTextureSize: 2048
     resizeAlgorithm: 0
     textureFormat: -1
-    textureCompression: 1
+    textureCompression: 0
     compressionQuality: 50
     crunchedCompression: 0
     allowsAlphaSplitting: 0

--- a/ProjectSettings/TagManager.asset
+++ b/ProjectSettings/TagManager.asset
@@ -6,6 +6,7 @@ TagManager:
   tags:
   - WaterParticle
   - Holding
+  - Wall
   layers:
   - Default
   - TransparentFX


### PR DESCRIPTION
Changed sprite drawing position to fit new sprite size. Also, like original game, sword attack range would shorter if stab wall. (Need a wall tag, or add other needed tag in further develop) As for kettle, now water particle would also disappear after hit. This influences original logic so I make it use a special particle to activate waterable objects.